### PR TITLE
feat(backend): add title filter

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -53,6 +53,10 @@ router.get("/", auth.optional, function(req, res, next) {
     query.tagList = { $in: [req.query.tag] };
   }
 
+  if (typeof req.query.title !== "undefined") {
+    query.title = { $in: [req.query.title] };
+  }
+
   Promise.all([
     req.query.seller ? User.findOne({ username: req.query.seller }) : null,
     req.query.favorited ? User.findOne({ username: req.query.favorited }) : null

--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -54,7 +54,8 @@ router.get("/", auth.optional, function(req, res, next) {
   }
 
   if (typeof req.query.title !== "undefined") {
-    query.title = { $in: [req.query.title] };
+    const regex =  new RegExp(req.query.title,'i');
+    query.title = regex;
   }
 
   Promise.all([


### PR DESCRIPTION
# Description

But, before we implement the full UI, we first need to add product filtering support to our API. In other words, when retrieving a list of items using a GET request, there should be an option to add a query filter called “title”, so that once we call this endpoint - the backend will show all the relevant items, whose title contains the same title query.
